### PR TITLE
Enable edits to the table to be saved when clicking "OK"

### DIFF
--- a/src/main/java/ghidrassist/SettingsDialog.java
+++ b/src/main/java/ghidrassist/SettingsDialog.java
@@ -317,6 +317,16 @@ public class SettingsDialog extends DialogComponentProvider {
         selectedProviderName = (String) activeProviderComboBox.getSelectedItem();
         selectedRagProviderName = (String) ragProviderComboBox.getSelectedItem();
 
+        // Sync table data to apiProviders list
+        for (int i = 0; i < tableModel.getRowCount(); i++) {
+            APIProvider provider = apiProviders.get(i);
+            provider.setName((String) tableModel.getValueAt(i, 0));
+            provider.setModel((String) tableModel.getValueAt(i, 1));
+            provider.setMaxTokens((String) tableModel.getValueAt(i, 2));
+            provider.setUrl((String) tableModel.getValueAt(i, 3));
+            provider.setKey((String) tableModel.getValueAt(i, 4));
+            provider.setDisableTlsVerification((Boolean) tableModel.getValueAt(i, 5));
+        }
 
         // Serialize the list of providers to JSON
         Gson gson = new Gson();


### PR DESCRIPTION
This makes it so it isn't necessary for the user to click the "Edit" button for each API provider the user wants to edit. Instead, they can simply edit the cells in the table directly and click "OK" to save all their changes at once.