### PR TITLE
Add some CSS to make rendered code easier to read

### DIFF
--- a/src/main/java/ghidrassist/GhidrAssistProvider.java
+++ b/src/main/java/ghidrassist/GhidrAssistProvider.java
@@ -1328,7 +1328,7 @@ public class GhidrAssistProvider extends ComponentProvider {
         String feedbackLinks = "<br> <div style=\"text-align: center; color: grey; font-size: 18px;\"><a href='thumbsup'>&#128077;</a> | <a href='thumbsdown'>&#128078;</a></div>";
 
         // Optionally, wrap the HTML in basic tags to improve rendering
-        String wrappedHtml = "<html><body>" + html + feedbackLinks + "</body></html>";
+        String wrappedHtml = "<html><head><style>code { background-color: #f0f1f2; } pre code { background-color: #f6f8fa; } pre { margin-top: 0; margin-bottom: 8px; padding: 8px; font-size: 85%; line-height: 1.45; color: #1f2328; background-color: #f6f8fa; }</style></head><body>" + html + feedbackLinks + "</body></html>";
 
         return wrappedHtml;
     }


### PR DESCRIPTION
This adds some GitHub-like CSS styles to `code` and `pre` tags, which are generated by Markdown code blocks. With these style changes, it's now much easier for me to skim through the LLM output since I can tell at just a glance what is code and what is explanatory text.

Unfortunately, the CSS engine in Java Swing is extremely limited compared to modern browsers (no padding or font size changes in inline code blocks, no rounded corners on borders, etc.), so I wasn't able to make it quite as good as the GitHub style, but at least it's functional.


## Example


### Before

![Before, with original styling.](https://github.com/user-attachments/assets/b5d73dc0-2d05-46f4-8b6a-2567c385765f)


### After

![After, with new GitHub-style code blocks.](https://github.com/user-attachments/assets/b9dae7a6-259d-410c-96cd-9d7939be0e34)