### PR TITLE
Make the API provider table sync with the API provider list automatically

### DIFF
--- a/src/main/java/ghidrassist/SettingsDialog.java
+++ b/src/main/java/ghidrassist/SettingsDialog.java
@@ -317,16 +317,6 @@ public class SettingsDialog extends DialogComponentProvider {
         selectedProviderName = (String) activeProviderComboBox.getSelectedItem();
         selectedRagProviderName = (String) ragProviderComboBox.getSelectedItem();
 
-        // Sync table data to apiProviders list
-        for (int i = 0; i < tableModel.getRowCount(); i++) {
-            APIProvider provider = apiProviders.get(i);
-            provider.setName((String) tableModel.getValueAt(i, 0));
-            provider.setModel((String) tableModel.getValueAt(i, 1));
-            provider.setMaxTokens((String) tableModel.getValueAt(i, 2));
-            provider.setUrl((String) tableModel.getValueAt(i, 3));
-            provider.setKey((String) tableModel.getValueAt(i, 4));
-            provider.setDisableTlsVerification((Boolean) tableModel.getValueAt(i, 5));
-        }
 
         // Serialize the list of providers to JSON
         Gson gson = new Gson();


### PR DESCRIPTION
Apologies for creating another PR for essentially the same improvement--I had marked #5 as a draft since I had an idea for how to do it better and was planning to force-push the new changes to the branch, but didn't finish implementing it all until after you had already merged that PR. I probably should have mentioned why I had marked it as a draft--sorry about that!

This improves upon the previous changes by using a table model listener to update the API providers list on every edit, meaning we no longer have to perform an explicit sync when clicking "OK" or at any other time--it just happens automatically when the table is edited, wherever it's edited from. So now the "Edit" dialogue will no longer be inconsistent with the state of the table. Also, unlike the previous iteration, this one extends the table model to automatically trim the whitespace from edited fields, and like with the table model listener, it just happens automatically no matter where the edit came from.