### PR TITLE
Add syntax highlighting to fenced code blocks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,27 @@ dependencies {
 	implementation 'org.apache.lucene:lucene-core:9.11.1'
 	implementation 'org.apache.lucene:lucene-analysis-common:9.11.1'
 	implementation 'org.apache.lucene:lucene-queryparser:9.11.1'
+	implementation 'org.jruby:jruby-complete:9.4.9.0'
 
 }
+
+def gemInstallDir = "${project.buildDir}/jruby.home"
+
+task installRougeGem(type: Exec) {
+	// Ensure this task runs after dependencies are resolved
+	dependsOn configurations.runtimeClasspath
+
+	doFirst {
+		// Install rouge
+		def jrubyJar = configurations.runtimeClasspath.filter { it.name.contains('jruby-complete') }.first()
+		println "Using JRuby JAR: ${jrubyJar.absolutePath}"
+		commandLine 'java', '-jar', jrubyJar.absolutePath, '-S', 'gem', 'install', '-i', gemInstallDir, 'rouge', '-v', '4.5.1', '--no-document'
+	}
+}
+
+// Include the Ruby gems in the JAR file
+jar.into('META-INF/jruby.home') { from gemInstallDir }
+jar.dependsOn installRougeGem
 
 // Exclude additional files from the built extension
 // Ex: buildExtension.exclude '.idea/**'

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
 	implementation 'com.launchableinc.openai-java:service:0.4.0'
 	implementation "io.reactivex.rxjava3:rxjava:3.1.9"
-	implementation 'com.vladsch.flexmark:flexmark-all:0.64.0'
+	implementation 'com.vladsch.flexmark:flexmark-all:0.64.8'
 	implementation 'org.xerial:sqlite-jdbc:3.46.1.0'
 	implementation 'org.apache.lucene:lucene-core:9.11.1'
 	implementation 'org.apache.lucene:lucene-analysis-common:9.11.1'


### PR DESCRIPTION
Draft PR for discussion/testing/visibility. Please **do not merge this** until the performance issues have been fixed--they can cause Ghidra to completely freeze for 10+ seconds a a time! If you try these changes you'll see what I mean. Please let me know if you have any ideas on how to resolve them, as I'd really like to be able to have syntax highlighting in fenced code blocks.

Also, we may want to make the theme changeable in the settings dialogue--it's hardcoded for now.

The way that JRuby loads the Rouge gem feels like a giant hack, but after hours and hours of trying to get it to work at all I got too impatient to try and do it correctly (assuming a "correct" way even exists). I'm neither a Java dev nor a Ruby dev, so that whole experience was... very challenging. Suggestions very much welcome!

<hr/>

This code adds a custom NodeRenderer extension that uses JRuby to run Rouge to perform syntax highlighting on fenced code blocks. The syntax highlighting makes it easier to understand large blocks of code at a glance.

Unfortunately this has major performance issues. The first major issue is that it takes several seconds for JRuby to start up, so the first time the "Explain Function" (etc.) button is clicked, Ghidra will freeze for those seconds while JRuby initializes. This is annoying, but relatively low-impact since that start-up cost is only paid once per Ghidra session, and I assume most users aren't repeatedly closing and re-opening Ghidra.

The second issue is much more impactful. When processing longer responses from the LLM, Ghidra starts freezing as it gets to the end of the message. I think this is happening because it's re-rendering the syntax highlighting for every new chunk of text. So as the full message gets longer it takes correspondingly longer to re-render it, and eventually it takes so long to render that it can't be finished before the next chunk arrives. At that point, it just gets completely stuck until the arrival of the final chunk.

Maybe there's a way to make it so the chunks can still be received and kept in a buffer while the full message is rendering? So when the rendering finishes it can append all the new chunks to the message before it tries to render it, rather than appending and re-rendering each chunk individually.