### PR TITLE
Security enhancements to HTML rendering

### DIFF
--- a/src/main/java/ghidrassist/GhidrAssistProvider.java
+++ b/src/main/java/ghidrassist/GhidrAssistProvider.java
@@ -171,9 +171,9 @@ public class GhidrAssistProvider extends ComponentProvider {
             public void hyperlinkUpdate(HyperlinkEvent e) {
                 if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
                     String desc = e.getDescription();
-                    if (desc.equals("thumbsup")) {
+                    if (desc.equals("#ghidrassist-thumbs-up")) {
                         storeRLHFFeedback(1);
-                    } else if (desc.equals("thumbsdown")) {
+                    } else if (desc.equals("#ghidrassist-thumbs-down")) {
                         storeRLHFFeedback(0);
                     }
                 }
@@ -218,9 +218,9 @@ public class GhidrAssistProvider extends ComponentProvider {
             public void hyperlinkUpdate(HyperlinkEvent e) {
                 if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
                     String desc = e.getDescription();
-                    if (desc.equals("thumbsup")) {
+                    if (desc.equals("#ghidrassist-thumbs-up")) {
                         storeRLHFFeedback(1);
-                    } else if (desc.equals("thumbsdown")) {
+                    } else if (desc.equals("#ghidrassist-thumbs-down")) {
                         storeRLHFFeedback(0);
                     }
                 }
@@ -1335,7 +1335,7 @@ public class GhidrAssistProvider extends ComponentProvider {
         String html = htmlRenderer.render(document);
 
         // Add RLHF feedback thumbs-up / thumbs-down buttons
-        String feedbackLinks = "<br> <div style=\"text-align: center; color: grey; font-size: 18px;\"><a href='thumbsup'>&#128077;</a> | <a href='thumbsdown'>&#128078;</a></div>";
+        String feedbackLinks = "<br> <div style=\"text-align: center; color: grey; font-size: 18px;\"><a href='#ghidrassist-thumbs-up'>&#128077;</a> | <a href='#ghidrassist-thumbs-down'>&#128078;</a></div>";
 
         // Optionally, wrap the HTML in basic tags to improve rendering
         String wrappedHtml = "<html><head><style>code { background-color: #f0f1f2; } pre code { background-color: #f6f8fa; } pre { margin-top: 0; margin-bottom: 8px; padding: 8px; font-size: 85%; line-height: 1.45; color: #1f2328; background-color: #f6f8fa; }</style></head><body>" + html + feedbackLinks + "</body></html>";

--- a/src/main/java/ghidrassist/GhidrAssistProvider.java
+++ b/src/main/java/ghidrassist/GhidrAssistProvider.java
@@ -15,6 +15,7 @@ import ghidra.util.task.TaskLauncher;
 import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
+import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.table.DefaultTableModel;
 
 import java.awt.BorderLayout;
@@ -143,6 +144,13 @@ public class GhidrAssistProvider extends ComponentProvider {
         panel.add(tabbedPane, BorderLayout.CENTER);
     }
 
+    static class SecureHTMLEditorKit extends HTMLEditorKit {
+        @Override
+        public HTMLEditorKit.Parser getParser() {
+            return new SecureParserDelegator();
+        }
+    }
+
     private JPanel createExplainTab() {
         JPanel explainPanel = new JPanel(new BorderLayout());
 
@@ -157,6 +165,7 @@ public class GhidrAssistProvider extends ComponentProvider {
         explainTextPane = new JEditorPane();
         explainTextPane.setEditable(false);
         explainTextPane.setContentType("text/html"); // Set content type to HTML
+        explainTextPane.setEditorKit(new SecureHTMLEditorKit());
         explainTextPane.addHyperlinkListener(new HyperlinkListener() {
             @Override
             public void hyperlinkUpdate(HyperlinkEvent e) {
@@ -203,6 +212,7 @@ public class GhidrAssistProvider extends ComponentProvider {
         responseTextPane = new JEditorPane();
         responseTextPane.setEditable(false);
         responseTextPane.setContentType("text/html"); // Set content type to HTML
+        responseTextPane.setEditorKit(new SecureHTMLEditorKit());
         responseTextPane.addHyperlinkListener(new HyperlinkListener() {
             @Override
             public void hyperlinkUpdate(HyperlinkEvent e) {

--- a/src/main/java/ghidrassist/GhidrAssistProvider.java
+++ b/src/main/java/ghidrassist/GhidrAssistProvider.java
@@ -175,6 +175,8 @@ public class GhidrAssistProvider extends ComponentProvider {
                         storeRLHFFeedback(1);
                     } else if (desc.equals("#ghidrassist-thumbs-down")) {
                         storeRLHFFeedback(0);
+                    } else {
+                        Msg.showInfo(getClass(), panel, "Unsupported Link", "This link is not supported.");
                     }
                 }
             }
@@ -222,6 +224,8 @@ public class GhidrAssistProvider extends ComponentProvider {
                         storeRLHFFeedback(1);
                     } else if (desc.equals("#ghidrassist-thumbs-down")) {
                         storeRLHFFeedback(0);
+                    } else {
+                        Msg.showInfo(getClass(), panel, "Unsupported Link", "This link is not supported.");
                     }
                 }
             }

--- a/src/main/java/ghidrassist/SecureParserDelegator.java
+++ b/src/main/java/ghidrassist/SecureParserDelegator.java
@@ -1,0 +1,53 @@
+package ghidrassist;
+
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.html.parser.ParserDelegator;
+import java.io.Reader;
+import java.io.IOException;
+
+public class SecureParserDelegator extends ParserDelegator {
+    @Override
+    public void parse(Reader r, HTMLEditorKit.ParserCallback cb, boolean ignoreCharset) throws IOException {
+        super.parse(r, new FilteringCallback(cb), ignoreCharset);
+    }
+
+    private static class FilteringCallback extends HTMLEditorKit.ParserCallback {
+        private final HTMLEditorKit.ParserCallback original;
+
+        public FilteringCallback(HTMLEditorKit.ParserCallback original) {
+            this.original = original;
+        }
+
+        @Override
+        public void handleStartTag(HTML.Tag t, MutableAttributeSet a, int pos) {
+            if (t == HTML.Tag.IMG) {
+                handleText("[Image removed by GhidrAssist]".toCharArray(), pos);
+            } else {
+                original.handleStartTag(t, a, pos);
+            }
+        }
+
+        @Override
+        public void handleEndTag(HTML.Tag t, int pos) {
+            if (t != HTML.Tag.IMG) {
+                original.handleEndTag(t, pos);
+            }
+        }
+
+        @Override
+        public void handleSimpleTag(HTML.Tag t, MutableAttributeSet a, int pos) {
+            if (t == HTML.Tag.IMG) {
+                handleText("[Image removed by GhidrAssist]".toCharArray(), pos);
+            } else {
+                original.handleSimpleTag(t, a, pos);
+            }
+        }
+
+        @Override
+        public void handleText(char[] data, int pos) {
+            original.handleText(data, pos);
+        }
+    }
+}

--- a/src/main/java/ghidrassist/SecureParserDelegator.java
+++ b/src/main/java/ghidrassist/SecureParserDelegator.java
@@ -4,6 +4,7 @@ import javax.swing.text.html.HTML;
 import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.text.MutableAttributeSet;
 import javax.swing.text.html.parser.ParserDelegator;
+import javax.swing.text.SimpleAttributeSet;
 import java.io.Reader;
 import java.io.IOException;
 
@@ -24,6 +25,15 @@ public class SecureParserDelegator extends ParserDelegator {
         public void handleStartTag(HTML.Tag t, MutableAttributeSet a, int pos) {
             if (t == HTML.Tag.IMG) {
                 handleText("[Image removed by GhidrAssist]".toCharArray(), pos);
+            } else if (t == HTML.Tag.A) {
+                String href = (String) a.getAttribute(HTML.Attribute.HREF);
+                if (href != null && !href.startsWith("#")) {
+                    MutableAttributeSet newAttributes = new SimpleAttributeSet();
+                    newAttributes.addAttribute(HTML.Attribute.HREF, "#ghidrassist-link-removed");
+                    original.handleStartTag(t, newAttributes, pos);
+                } else {
+                    original.handleStartTag(t, a, pos);
+                }
             } else {
                 original.handleStartTag(t, a, pos);
             }
@@ -40,6 +50,15 @@ public class SecureParserDelegator extends ParserDelegator {
         public void handleSimpleTag(HTML.Tag t, MutableAttributeSet a, int pos) {
             if (t == HTML.Tag.IMG) {
                 handleText("[Image removed by GhidrAssist]".toCharArray(), pos);
+            } else if (t == HTML.Tag.A) {
+                String href = (String) a.getAttribute(HTML.Attribute.HREF);
+                if (href != null && !href.startsWith("#")) {
+                    MutableAttributeSet newAttributes = new SimpleAttributeSet();
+                    newAttributes.addAttribute(HTML.Attribute.HREF, "#ghidrassist-link-removed");
+                    original.handleSimpleTag(t, newAttributes, pos);
+                } else {
+                    original.handleSimpleTag(t, a, pos);
+                }
             } else {
                 original.handleSimpleTag(t, a, pos);
             }


### PR DESCRIPTION
After some testing, I discovered that the `JEditorPane` will load external images if it's presented with a valid `img` tag, which poses some risks if the LLM (or someone MitM-ing the connection) decides to inject malicious images or tags into the markdown. To mitigate these risks, we can simply remove all `img` tags during HTML parsing, making it impossible for images defined in Markdown or raw HTML to be fetched or rendered at all. To let the user know that an image was removed, in place of the `img` tag we add the text "[Image removed by GhidrAssist]".

Building on this, to mitigate the risk that the user might click a malicious link in the HTML we can also remove all external links. This may not be completely necessary, since I think the HyperlinkListener is blocking clicks of all unhandled links already, but just for good measure I modified the SecureParserDelegator to also strip out external links. I also added a notification when the user clicks on a link that isn't one of the thumbs-up / thumbs-down links, so they aren't confused if they happen to click on a link and nothing happens (the behavior before this patch).