### PR TITLE
Add missing okio and okhttp dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,8 @@ dependencies {
 	implementation 'org.apache.lucene:lucene-core:9.11.1'
 	implementation 'org.apache.lucene:lucene-analysis-common:9.11.1'
 	implementation 'org.apache.lucene:lucene-queryparser:9.11.1'
-
+	implementation 'com.squareup.okio:okio:3.10.2'
+	implementation "com.squareup.okhttp3:okhttp:4.12.0"
 }
 
 // Exclude additional files from the built extension


### PR DESCRIPTION
Add `okio v3.10.2` and `okhttp v4.12.0` to `build.gradle` otherwise build will fail with 
```
AnthropicProvider.java:9: error: package okio does not exist 
import okio.BufferedSource;
```

and 
```
APIProvider.java:12: error: package okhttp3 does not exist
import okhttp3.OkHttpClient;
```
errors