### PR TITLE
Fix NPE when deleting the last LLM provider

### DIFF
--- a/src/main/java/ghidrassist/ui/tabs/SettingsTab.java
+++ b/src/main/java/ghidrassist/ui/tabs/SettingsTab.java
@@ -432,7 +432,8 @@ public class SettingsTab extends JPanel {
     private void setupListeners() {
         // Active provider change
         activeProviderComboBox.addActionListener(e -> {
-            selectedProviderName = (String) activeProviderComboBox.getSelectedItem();
+            String item = (String) activeProviderComboBox.getSelectedItem();
+            selectedProviderName = (item != null) ? item : "";
             Preferences.setProperty("GhidrAssist.SelectedAPIProvider", selectedProviderName);
             Preferences.store();
         });


### PR DESCRIPTION
Deleting the last provider from the LLM Providers table throws NPE.

The crash site is `onDeleteProvider()` line 616, but the root cause is the `activeProviderComboBox` action listener in `setupListeners()`:

1. `onDeleteProvider()` calls `activeProviderComboBox.removeItemAt(selectedRow)` - removes the only item from the combo box.
2. Swing fires the action listener.
3. The listener sets `selectedProviderName = (String) activeProviderComboBox.getSelectedItem()` - returns `null` because the combo box is now empty.
4. The listener persists `null` into `Preferences.setProperty("GhidrAssist.SelectedAPIProvider", null)`.
5. Back in `onDeleteProvider()`, `selectedProviderName.equals(provider.getName())` throws NPE.

The fix is to null-coalesce `getSelectedItem()` to `""` in the listener so that `selectedProviderName` is never `null`.

---

I built the extension from source to validate this fix.
Steps to reproduce the bug without this fix:

1. Add one LLM provider if there are none yet, or delete all except one LLM provider.
2. Delete it - an NPE will be thrown.

After this proposed fix, this bug can no longer be reproduced.