### PR TITLE
Fix OAI Tool Calls where `name` is null

### DIFF
--- a/src/main/java/ghidrassist/apiprovider/OpenAIPlatformApiProvider.java
+++ b/src/main/java/ghidrassist/apiprovider/OpenAIPlatformApiProvider.java
@@ -833,16 +833,16 @@ public class OpenAIPlatformApiProvider extends APIProvider implements FunctionCa
 
                                                         ToolCallAccumulator acc = toolCallsMap.computeIfAbsent(index, k -> new ToolCallAccumulator());
 
-                                                        if (toolCallDelta.has("id")) {
+                                                        if (toolCallDelta.has("id") && !toolCallDelta.get("id").isJsonNull()) {
                                                             acc.id = toolCallDelta.get("id").getAsString();
                                                         }
 
                                                         if (toolCallDelta.has("function")) {
                                                             JsonObject functionDelta = toolCallDelta.getAsJsonObject("function");
-                                                            if (functionDelta.has("name")) {
+                                                            if (functionDelta.has("name") && !functionDelta.get("name").isJsonNull()) {
                                                                 acc.name = functionDelta.get("name").getAsString();
                                                             }
-                                                            if (functionDelta.has("arguments")) {
+                                                            if (functionDelta.has("arguments") && !functionDelta.get("arguments").isJsonNull()) {
                                                                 acc.argumentsBuffer.append(functionDelta.get("arguments").getAsString());
                                                             }
                                                         }


### PR DESCRIPTION
I kept running into exceptions on version `1.17.0` with the Query functionality using an OAI Compatible Endpoint (vLLM running Qwen3 Coder Next) where it'd throw an exception on line 843

    acc.name = functionDelta.get("name").getAsString();

The condition gating that assignment only checks if `name` is present and will throw a `JsonNull` exception if the OAI response has that field set to `null`. I'm not sure why it would be null but after this change the Query functionality works and tool calls are working successfully.