### PR TITLE
Fix Query streaming document crash and improve local provider behavior

### DIFF
--- a/src/main/java/ghidrassist/apiprovider/LMStudioProvider.java
+++ b/src/main/java/ghidrassist/apiprovider/LMStudioProvider.java
@@ -38,7 +38,21 @@ public class LMStudioProvider extends APIProvider implements FunctionCallingProv
                 .connectTimeout(super.timeout)
                 .readTimeout(super.timeout)
                 .writeTimeout(super.timeout)
-                .retryOnConnectionFailure(true);
+                .retryOnConnectionFailure(true)
+                .addInterceptor(chain -> {
+                    Request originalRequest = chain.request();
+                    Request.Builder requestBuilder = originalRequest.newBuilder()
+                        .header("Content-Type", "application/json");
+
+                    String apiKey = key != null ? key.trim() : "";
+                    if (!apiKey.isEmpty()) {
+                        // Support API-key-protected OpenAI-compatible local endpoints.
+                        // LM Studio itself may not require this, but remote/proxied servers often do.
+                        requestBuilder.header("Authorization", "Bearer " + apiKey);
+                    }
+
+                    return chain.proceed(requestBuilder.build());
+                });
 
             if (disableTlsVerification) {
                 TrustManager[] trustAllCerts = new TrustManager[]{

--- a/src/main/java/ghidrassist/core/TabController.java
+++ b/src/main/java/ghidrassist/core/TabController.java
@@ -1196,6 +1196,16 @@ public class TabController {
     public void handleHyperlinkEvent(HyperlinkEvent e) {
         if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
             String desc = e.getDescription();
+
+            // Feedback links can appear when viewing old chat content.
+            // In that case there may be no in-memory "latest interaction" cached yet.
+            if (("thumbsup".equals(desc) || "thumbsdown".equals(desc))
+                    && !feedbackService.hasPendingFeedback()) {
+                Msg.showInfo(getClass(), null, "Feedback",
+                    "No recent response is cached for feedback yet. Run a new query first.");
+                return;
+            }
+
             try {
                 if (desc.equals("thumbsup")) {
                     feedbackService.storePositiveFeedback();
@@ -1204,6 +1214,8 @@ public class TabController {
                     feedbackService.storeNegativeFeedback();
                     Msg.showInfo(getClass(), null, "Feedback", "Thank you for your feedback!");
                 }
+            } catch (IllegalStateException ex) {
+                Msg.showInfo(getClass(), null, "Feedback", ex.getMessage());
             } catch (Exception ex) {
                 Msg.showError(this, null, "Error", "Failed to store feedback: " + ex.getMessage());
             }

--- a/src/main/java/ghidrassist/services/QueryService.java
+++ b/src/main/java/ghidrassist/services/QueryService.java
@@ -233,6 +233,13 @@ public class QueryService {
         ghidra.program.model.address.Address currentAddress = plugin.getCurrentAddress();
         if (currentProgram != null) {
             toolRegistry.setFullContext(currentProgram, currentAddress);
+        } else {
+            // No active binary context: fall back to plain chat mode.
+            // Native tools depend on program/address and can cause incomplete
+            // tool-calling loops when no program is loaded.
+            ghidra.util.Msg.info(this, "No program context - using regular query mode (native tools disabled)");
+            executeRegularQuery(request, llmApi, handler);
+            return;
         }
 
         // Get native tools only (MCP tools won't be registered since MCP is disabled)

--- a/src/main/java/ghidrassist/tools/native_/ActionToolProvider.java
+++ b/src/main/java/ghidrassist/tools/native_/ActionToolProvider.java
@@ -94,6 +94,10 @@ public class ActionToolProvider implements ToolProvider {
 
     @Override
     public List<Tool> getTools() {
+        if (currentProgram == null || currentAddress == null) {
+            return java.util.Collections.emptyList();
+        }
+
         List<Tool> tools = new ArrayList<>();
         for (ActionToolDef def : ACTION_TOOLS.values()) {
             // Add prefix to tool name

--- a/src/main/java/ghidrassist/tools/native_/GhidraToolProvider.java
+++ b/src/main/java/ghidrassist/tools/native_/GhidraToolProvider.java
@@ -40,6 +40,10 @@ public class GhidraToolProvider implements ToolProvider {
 
     @Override
     public List<Tool> getTools() {
+        if (currentProgram == null || currentAddress == null) {
+            return java.util.Collections.emptyList();
+        }
+
         List<Tool> tools = new ArrayList<>();
 
         // ga.get_current_function

--- a/src/main/java/ghidrassist/ui/tabs/QueryTab.java
+++ b/src/main/java/ghidrassist/ui/tabs/QueryTab.java
@@ -305,7 +305,7 @@ public class QueryTab extends JPanel {
      * Preserves scroll position if user has scrolled up from bottom.
      */
     public void setResponseText(String htmlText) {
-        SwingUtilities.invokeLater(() -> {
+        Runnable updateUi = () -> {
             try {
                 // Capture scroll state BEFORE any modifications
                 boolean wasAtBottom = scrollManager.isAtBottom();
@@ -313,6 +313,7 @@ public class QueryTab extends JPanel {
 
                 // Switch to HTML mode for final markdown rendering
                 responseTextPane.setContentType("text/html");
+                responseTextPane.setEditorKit(new HTMLEditorKit());
                 responseTextPane.setText(htmlText);
 
                 // Restore scroll position - only auto-scroll if user was at bottom
@@ -326,7 +327,13 @@ public class QueryTab extends JPanel {
             } catch (Exception e) {
                 Msg.error(this, "Error setting response text", e);
             }
-        });
+        };
+
+        if (SwingUtilities.isEventDispatchThread()) {
+            updateUi.run();
+        } else {
+            SwingUtilities.invokeLater(updateUi);
+        }
     }
 
     /**
@@ -336,7 +343,7 @@ public class QueryTab extends JPanel {
      * @param prefixHtml Pre-rendered HTML for conversation history (may be empty)
      */
     public void initializeForStreaming(String prefixHtml) {
-        SwingUtilities.invokeLater(() -> {
+        Runnable initializeUi = () -> {
             // Capture scroll state BEFORE any modifications
             boolean wasAtBottom = scrollManager.isAtBottom();
             int savedScrollValue = scrollManager.getScrollPane().getVerticalScrollBar().getValue();
@@ -370,7 +377,13 @@ public class QueryTab extends JPanel {
                 SwingUtilities.invokeLater(() ->
                         scrollManager.getScrollPane().getVerticalScrollBar().setValue(savedScrollValue));
             }
-        });
+        };
+
+        if (SwingUtilities.isEventDispatchThread()) {
+            initializeUi.run();
+        } else {
+            SwingUtilities.invokeLater(initializeUi);
+        }
     }
 
     /**
@@ -422,7 +435,12 @@ public class QueryTab extends JPanel {
             return;
         }
 
-        HTMLDocument doc = (HTMLDocument) responseTextPane.getDocument();
+        HTMLDocument doc = ensureHtmlDocument();
+        if (doc == null) {
+            documentCorrupted = true;
+            rebuildDocument();
+            return;
+        }
 
         try {
             // Append committed HTML
@@ -454,6 +472,8 @@ public class QueryTab extends JPanel {
         if (fullHtml != null) {
             String wrapped = "<html><head><style>" + STREAMING_CSS + "</style></head><body>" +
                     fullHtml + "</body></html>";
+            responseTextPane.setContentType("text/html");
+            responseTextPane.setEditorKit(new HTMLEditorKit());
             responseTextPane.setText(wrapped);
             documentCorrupted = false;
         }
@@ -464,7 +484,40 @@ public class QueryTab extends JPanel {
                 accumulatedCommittedHtml.toString() +
                 lastPendingHtml +
                 "</body></html>";
+        responseTextPane.setContentType("text/html");
+        responseTextPane.setEditorKit(new HTMLEditorKit());
         responseTextPane.setText(html);
+    }
+
+    /**
+     * Ensure the response pane has an HTMLDocument.
+     * When streaming starts before HTML initialization finishes, Swing may still
+     * expose a DefaultStyledDocument. Recover by rebuilding the HTML document.
+     */
+    private HTMLDocument ensureHtmlDocument() {
+        Document currentDoc = responseTextPane.getDocument();
+        if (currentDoc instanceof HTMLDocument) {
+            return (HTMLDocument) currentDoc;
+        }
+
+        Msg.warn(this, "Query response document is not HTMLDocument (" +
+                currentDoc.getClass().getName() + "); rebuilding HTML view.");
+
+        responseTextPane.setContentType("text/html");
+        responseTextPane.setEditorKit(new HTMLEditorKit());
+        String repairedHtml = "<html><head><style>" + STREAMING_CSS + "</style></head><body>" +
+                "<div id=\"committed\">" + accumulatedCommittedHtml + "</div>" +
+                "<div id=\"pending\">" + lastPendingHtml + "</div>" +
+                "</body></html>";
+        responseTextPane.setText(repairedHtml);
+
+        Document repairedDoc = responseTextPane.getDocument();
+        if (repairedDoc instanceof HTMLDocument) {
+            return (HTMLDocument) repairedDoc;
+        }
+
+        Msg.error(this, "Failed to recover HTMLDocument for query streaming", null);
+        return null;
     }
 
     private Element findElement(HTMLDocument doc, String id) {


### PR DESCRIPTION
## Summary
- fix Query streaming crash caused by casting `DefaultStyledDocument` to `HTMLDocument`
- make Query streaming initialization/document handling EDT-safe and add HTML document recovery
- improve no-context behavior by disabling native tool exposure when no program/address is loaded and falling back to regular chat
- send `Authorization: Bearer <key>` for LM Studio provider requests to support API-key-protected OpenAI-compatible endpoints
- show an informational feedback message when no recent interaction is cached instead of surfacing an error dialog

## Validation
- `gradle -PGHIDRA_INSTALL_DIR=<path-to-ghidra-install> compileJava`
- `gradle -PGHIDRA_INSTALL_DIR=<path-to-ghidra-install> buildExtension`
