### PR TITLE
Fix DeepSeek reasoning_content not passed back in multi-turn conversations

### DIFF
--- a/src/main/java/ghidrassist/apiprovider/LiteLLMProvider.java
+++ b/src/main/java/ghidrassist/apiprovider/LiteLLMProvider.java
@@ -392,6 +392,7 @@ public class LiteLLMProvider extends OpenAIPlatformApiProvider {
 
                     BufferedSource source = responseBody.source();
                     StringBuilder textBuilder = new StringBuilder();
+                    StringBuilder reasoningBuilder = new StringBuilder();
                     java.util.Map<Integer, ToolCallAccumulator> toolCallsMap = new java.util.HashMap<>();
                     String finishReason = "stop";
 
@@ -416,7 +417,8 @@ public class LiteLLMProvider extends OpenAIPlatformApiProvider {
                                                 toolCalls.add(new ToolCall(acc.id, acc.name, args));
                                             });
 
-                                    handler.onStreamComplete(finishReason, textBuilder.toString(), toolCalls);
+                                    handler.onStreamComplete(finishReason, textBuilder.toString(),
+                                        reasoningBuilder.toString(), toolCalls);
                                     return;
                                 }
 
@@ -436,6 +438,11 @@ public class LiteLLMProvider extends OpenAIPlatformApiProvider {
                                                     String content = delta.get("content").getAsString();
                                                     textBuilder.append(content);
                                                     handler.onTextUpdate(content);
+                                                }
+
+                                                // Capture reasoning_content (DeepSeek thinking mode)
+                                                if (delta.has("reasoning_content") && !delta.get("reasoning_content").isJsonNull()) {
+                                                    reasoningBuilder.append(delta.get("reasoning_content").getAsString());
                                                 }
 
                                                 // Buffer tool calls

--- a/src/main/java/ghidrassist/apiprovider/OpenAIPlatformApiProvider.java
+++ b/src/main/java/ghidrassist/apiprovider/OpenAIPlatformApiProvider.java
@@ -708,6 +708,12 @@ public class OpenAIPlatformApiProvider extends APIProvider implements FunctionCa
                 messageObj.addProperty("content", "");
             }
 
+            // Include reasoning_content for assistant messages (required by DeepSeek thinking mode)
+            if (ChatMessage.ChatMessageRole.ASSISTANT.equals(message.getRole()) &&
+                    message.getThinkingContent() != null && !message.getThinkingContent().isEmpty()) {
+                messageObj.addProperty("reasoning_content", message.getThinkingContent());
+            }
+
             // Handle tool calls for assistant messages
             if (message.getToolCalls() != null) {
                 messageObj.add("tool_calls", message.getToolCalls());
@@ -917,7 +923,7 @@ public class OpenAIPlatformApiProvider extends APIProvider implements FunctionCa
          * @param fullText The complete text content
          * @param toolCalls List of tool calls (empty if none)
          */
-        void onStreamComplete(String stopReason, String fullText, List<ToolCall> toolCalls);
+        void onStreamComplete(String stopReason, String fullText, String reasoningContent, List<ToolCall> toolCalls);
 
         /**
          * Called when an error occurs during streaming.
@@ -1026,6 +1032,7 @@ public class OpenAIPlatformApiProvider extends APIProvider implements FunctionCa
 
                     BufferedSource source = responseBody.source();
                     StringBuilder textBuilder = new StringBuilder();
+                    StringBuilder reasoningBuilder = new StringBuilder();
                     java.util.Map<Integer, ToolCallAccumulator> toolCallsMap = new java.util.HashMap<>();
                     String finishReason = "stop";
 
@@ -1059,7 +1066,8 @@ public class OpenAIPlatformApiProvider extends APIProvider implements FunctionCa
                                             toolCalls.add(new ToolCall(tcId, acc.name, args));
                                         });
 
-                                    handler.onStreamComplete(finishReason, textBuilder.toString(), toolCalls);
+                                    handler.onStreamComplete(finishReason, textBuilder.toString(),
+                                        reasoningBuilder.toString(), toolCalls);
                                     return;
                                 }
 
@@ -1080,6 +1088,11 @@ public class OpenAIPlatformApiProvider extends APIProvider implements FunctionCa
                                                     String content = delta.get("content").getAsString();
                                                     textBuilder.append(content);
                                                     handler.onTextUpdate(content);
+                                                }
+
+                                                // Capture reasoning_content (DeepSeek thinking mode)
+                                                if (delta.has("reasoning_content") && !delta.get("reasoning_content").isJsonNull()) {
+                                                    reasoningBuilder.append(delta.get("reasoning_content").getAsString());
                                                 }
 
                                                 // Buffer tool calls

--- a/src/main/java/ghidrassist/core/ConversationalToolHandler.java
+++ b/src/main/java/ghidrassist/core/ConversationalToolHandler.java
@@ -575,8 +575,13 @@ public class ConversationalToolHandler {
                     }
 
                     @Override
-                    public void onStreamComplete(String stopReason, String fullText, List<OpenAIPlatformApiProvider.ToolCall> toolCalls) {
+                    public void onStreamComplete(String stopReason, String fullText, String reasoningContent, List<OpenAIPlatformApiProvider.ToolCall> toolCalls) {
                         ChatMessage assistantMsg = new ChatMessage(ChatMessage.ChatMessageRole.ASSISTANT, fullText);
+
+                        // Store reasoning_content so it can be passed back on the next turn (DeepSeek requirement)
+                        if (reasoningContent != null && !reasoningContent.isEmpty()) {
+                            assistantMsg.setThinkingContent(reasoningContent);
+                        }
 
                         // Only attach tool calls when stopReason indicates tool calling.
                         // If stopReason is "stop" but streaming accumulated partial tool call deltas,
@@ -1043,7 +1048,15 @@ public class ConversationalToolHandler {
             if (assistantMessage.has("tool_calls")) {
                 assistantMsg.setToolCalls(assistantMessage.getAsJsonArray("tool_calls"));
             }
-            
+
+            // Store reasoning_content so it can be passed back on the next turn (DeepSeek requirement)
+            if (assistantMessage.has("reasoning_content") && !assistantMessage.get("reasoning_content").isJsonNull()) {
+                String reasoningContent = assistantMessage.get("reasoning_content").getAsString();
+                if (!reasoningContent.isEmpty()) {
+                    assistantMsg.setThinkingContent(reasoningContent);
+                }
+            }
+
             conversationHistory.add(assistantMsg);
             
             // Extract tool calls


### PR DESCRIPTION
## Problem
When using DeepSeek thinking models (e.g. `deepseek-v4-pro`), any request that triggers tool use fails on the second API call with:
```
The `reasoning_content` in the thinking mode must be passed back to the API.
```

## Fix
- Capture `reasoning_content` from streaming deltas in `OpenAIPlatformApiProvider` and `LiteLLMProvider`
- Thread it through `StreamingFunctionHandler.onStreamComplete` as a new parameter
- Store it in `ChatMessage.thinkingContent` and emit it as `reasoning_content` in subsequent turn payloads
- Non-streaming path also handles it

## Testing
Reproduced with `deepseek-v4-pro` — asking to explain a function with structure data triggers tool calls, which previously hit the error. After this fix the second turn completes successfully.